### PR TITLE
avoid exceeding PHP 'max_input_vars' by posting only a single string …

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -13,6 +13,35 @@ jQuery(function () {
         jQuery('.match input[id^=' + this.id.replace(/:/g, '\\:') + ']').prop('checked', this.checked);
     });
 
+    // When all single matches of a file have been checked, mark the appropriate "check all" box as checked, too.
+    jQuery('.check-single-match').click(function(){
+        var pageIdEscaped = this.id.substr(0, this.id.indexOf('#')).replace(/:/g, '\\:');
+        var checkedAll = true;
+        jQuery('.match input[id^=' + pageIdEscaped + ']').each(function(i, el) {
+            checkedAll = checkedAll && jQuery(el).prop('checked');
+            return checkedAll;
+        });
+        if (checkedAll) {
+            jQuery('#'+pageIdEscaped).prop('checked', true);
+        }
+    });
+
+    // Consolidate the list of all checked match ids into single hidden input field as
+    // a comma-separated string. This avoids problems for huge replacement sets
+    // exceeding `max_input_vars` in `php.ini`.
+    jQuery('#replace-form').submit(function() {
+      // Consolidate checked matches into a single string variable to be posted to the backend.
+      var checkedMatchesList='';
+      jQuery('.check-single-match').each(function(i, el) {
+        if (jQuery(el).prop('checked')) {
+          checkedMatchesList+=(el.id+',');
+        }
+      });
+      // cut off the last comma:
+      checkedMatchesList = checkedMatchesList.slice(0, -1);
+      jQuery("input[name=\'checkedMatches\']").val(checkedMatchesList);
+    });
+
     var totalStatsFloater = function() {
         var $anchor = jQuery('#totalstats');
         var $floater = $anchor.children('div');

--- a/admin.php
+++ b/admin.php
@@ -409,6 +409,7 @@ class admin_plugin_batchedit extends DokuWiki_Admin_Plugin {
      *
      */
     private function applyMatches() {
+        set_time_limit(120);
         foreach (array_keys($this->match) as $page) {
             if ($this->requiresChanges($page)) {
                 if ($this->isEditAllowed($page)) {
@@ -505,6 +506,7 @@ class admin_plugin_batchedit extends DokuWiki_Admin_Plugin {
      *
      */
     private function editPage($page) {
+        set_time_limit(120);
         lock($page);
 
         $text = rawWiki($page);


### PR DESCRIPTION
…of match ids;

Resolves #16 

Other added feature:
Mark 'check all' box for a page when all its matches have been checked individually.


I think this PR is cleaner than the last one, hopefully not requiring too much reworking. :)
