### PR TITLE
Bootstrap competes with jQuery Tooltip

### DIFF
--- a/interface.js
+++ b/interface.js
@@ -49,7 +49,8 @@ var batcheditInterface = (function () {
     }
 
     function initializeTooltip() {
-        jQuery('#batchedit').tooltip({
+        jQuery.widget.bridge('uitooltip', jQuery.ui.tooltip);
+        jQuery('#batchedit').uitooltip({
             tooltipClass: 'be-tooltip',
             show: {delay: 1000},
             track: true


### PR DESCRIPTION
Bootstrap templates (e.g. Argon Alternative) fails to load BatchEdit interface.js file because both jQuery UI and Bootstrap use tooltip for the name of the plugin. Use $.widget.bridge to create a different name for the jQuery UI version and allow the Bootstrap plugin to stay named tooltip.